### PR TITLE
binstar.org to anaconda.org

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ install:
    - export PATH="$HOME/miniconda/bin:$PATH"
    - conda config --set always_yes yes
    - conda config --set show_channel_urls True
-   - conda config --add channels http://conda.binstar.org/jakirkham
+   - conda config --add channels http://conda.anaconda.org/jakirkham
    - source activate root
    # Install basic conda dependencies.
    - conda update --all

--- a/.wercker.yml
+++ b/.wercker.yml
@@ -4,7 +4,7 @@ build:
         - script:
             name: Build Conda Package.
             code: |-
-                conda config --add channels http://conda.binstar.org/jakirkham
+                conda config --add channels http://conda.anaconda.org/jakirkham
                 conda config --set show_channel_urls True
                 source activate root
                 conda update -y --all

--- a/README.rst
+++ b/README.rst
@@ -54,5 +54,5 @@ way (as seen below).
    :target: http://opensource.org/licenses/BSD-3-Clause
 .. |Documentation| image:: https://img.shields.io/badge/docs-current-9F21E9.svg
    :target: http://jakirkham.github.io/splauncher/
-.. |Binstar Release| image:: https://binstar.org/jakirkham/splauncher/badges/version.svg
-   :target: https://binstar.org/jakirkham/splauncher
+.. |Binstar Release| image:: https://anaconda.org/jakirkham/splauncher/badges/version.svg
+   :target: https://anaconda.org/jakirkham/splauncher


### PR DESCRIPTION
[binstar.org](http://binstar.org) is being moved to [anaconda.org](http://anaconda.org). This can be evidenced by this brief note on top of this article ( http://continuum.io/blog/binstar ) and emails Continuum has been sending out. As a consequence, this PR simply replaces all the links to point [anaconda.org](http://anaconda.org).
