### PR TITLE
Ensure clean repo on Wercker

### DIFF
--- a/.wercker.yml
+++ b/.wercker.yml
@@ -2,6 +2,11 @@ box: jakirkham/centos_drmaa_conda
 build:
     steps:
         - script:
+            name: Ensure clean repo.
+            code: |-
+                git diff
+
+        - script:
             name: Build Conda Package.
             code: |-
                 conda config --add channels jakirkham


### PR DESCRIPTION
Apparently, the git repo will appear dirty even though `git status` reveals it to be clean. It turns out the non-invasive `git diff` corrects this problem. So, we use it before proceeding to build the package.

See related issues ( https://github.com/wercker/support/issues/101 ) ( https://github.com/docker/hub-beta-feedback/issues/270 ).
