### PR TITLE
Pin `conda-build` to 1.16.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,8 @@ install:
    - conda config --add channels jakirkham
    - source activate root
    # Install basic conda dependencies.
+   - touch $HOME/miniconda/conda-meta/pinned
+   - echo "conda-build ==1.16.0" >> $HOME/miniconda/conda-meta/pinned
    - conda update --all
    - conda install conda-build
    # Build the conda package for splauncher.

--- a/.wercker.yml
+++ b/.wercker.yml
@@ -11,6 +11,8 @@ build:
             code: |-
                 conda config --add channels jakirkham
                 conda config --set show_channel_urls True
+                touch /opt/conda/conda-meta/pinned
+                echo "conda-build ==1.16.0" >> /opt/conda/conda-meta/pinned
                 source activate root
                 conda update -y --all
                 python setup.py bdist_conda


### PR DESCRIPTION
It appears that `python setup.py bdist_conda` broke in 1.17.0. ( https://github.com/conda/conda-build/issues/555 ) So, this ensures that `conda-build` 1.16.0 is only used for building.
