### PR TITLE
Differentiates from/to emails on Wercker and to emails on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -97,6 +97,7 @@ after_success:
    - conda server -t ${AS_TOKEN} upload linux-64/splauncher*
    - conda server -t ${AS_TOKEN} upload osx-64/splauncher*
 notifications:
-  email: False
+  email:
+    - $TO_EMAIL
 # Use container format for TravisCI to avoid termination due to insufficient resources.
 #sudo: false

--- a/.wercker.yml
+++ b/.wercker.yml
@@ -61,7 +61,7 @@ build:
     after-steps:
         - jakirkham/email-notify:
             from: alerts@wercker.com
-            to: $USER
-            username: $USER
+            to: $TO_EMAIL
+            username: $FROM_EMAIL
             password: $PASS
             host: smtp.gmail.com:587


### PR DESCRIPTION
Will allow us to more easily try different forms of email notification.
