### PR TITLE
Travis workaround hostname length

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,11 @@ before_install:
    - deactivate
    - cd ../..
    - pwd
+   # Fix the hostname to have fewer characters for SGE.
+   - cat /etc/hosts # optionally check the content *before*
+   - sudo hostname "$(hostname | cut -c1-63)"
+   - sed -e "s/^\\(127\\.0\\.0\\.1.*\\)/\\1 $(hostname | cut -c1-63)/" /etc/hosts | sudo tee /etc/hosts
+   - cat /etc/hosts # optionally check the content *after*
 install:
    # Download and configure conda.
    - wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh


### PR DESCRIPTION
Travis CI on GCE has some sort of hostname length restriction. We work around this issue by changing the hostname to be within this length restriction.
