### PR TITLE
Support Python 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,7 +53,7 @@ install:
    - conda install nose-timer
    - echo "coverage 3.*" >> $HOME/miniconda/envs/testenv/conda-meta/pinned
    - conda install coverage
-   - conda install docstring-coverage
+   - conda install docstring-coverage || true
    - conda install python-coveralls
    # Clean up downloads as there are quite a few and they waste space/memory.
    - sudo apt-get clean
@@ -65,7 +65,7 @@ script:
    # Build documentation.
    - python setup.py build_sphinx
    # Get info on docstring coverage.
-   - docstring-coverage splauncher | tee .docstring-coverage
+   - (hash docstring-coverage && docstring-coverage nanshe | tee .docstring-coverage) || true
 after_success:
    # Submit results to coveralls.io.
    - coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,10 @@
 language: generic
 env:
-   - PYTHON_VERSION="2.7"
+   - PYTHON_VERSION="2.7" DEPLOY_DOCS=true
    - PYTHON_VERSION="3.5"
 before_install:
+   # If `$DEPLOY_DOCS` is unset, make it `false` by default.
+   - if [ -z $DEPLOY_DOCS ]; then DEPLOY_DOCS=false; fi
    # Get the tag if it wasn't provided. Travis doesn't provide this if it isn't a tagged build.
    - if [ -z $TRAVIS_TAG ]; then TRAVIS_TAG=`git tag --contains` ; fi
    - echo $TRAVIS_TAG
@@ -95,7 +97,7 @@ after_success:
    # Commit changes and push. Reference commit used and tag if relevant.
    - git add -A
    - if [ -z $TRAVIS_TAG ]; then git commit -m "Rebuilt documentation for commit (${TRAVIS_COMMIT})." --allow-empty ; else git commit -m "Rebuilt documentation for commit (${TRAVIS_COMMIT}) and tag (${TRAVIS_TAG})." --allow-empty ; fi
-   - git push -q origin gh-pages > /dev/null 2>&1; echo $?
+   - $DEPLOY_DOCS && (git push -q origin gh-pages > /dev/null 2>&1; echo $?)
    # Check to see if this is a release. If so, create and upload binaries.
    - if [ -z $TRAVIS_TAG ]; then exit 0 ; fi
    - git checkout $TRAVIS_TAG

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: generic
 env:
    - PYTHON_VERSION="2.7"
+   - PYTHON_VERSION="3.5"
 before_install:
    # Get the tag if it wasn't provided. Travis doesn't provide this if it isn't a tagged build.
    - if [ -z $TRAVIS_TAG ]; then TRAVIS_TAG=`git tag --contains` ; fi


### PR DESCRIPTION
- Run CI testing on Travis using Python 3.
- Skip installing `docstring-coverage` on Python 3 (not supported).
- Fix doc deployment to happen on a single build only.
