### PR TITLE
Include the license file

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include LICENSE.txt


### PR DESCRIPTION
Make sure the license file is include in any `sdist`s or other packages made.
