### PR TITLE
Pin conda-build to 1.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,7 @@ install:
    - conda update --all
    # Fix root environment to have the correct Python version.
    - touch $HOME/miniconda/conda-meta/pinned
+   - echo "conda-build 1.*" >> $HOME/miniconda/conda-meta/pinned
    - echo "python ${PYTHON_VERSION}.*" >> $HOME/miniconda/conda-meta/pinned
    - conda install python=$PYTHON_VERSION
    # Install basic conda dependencies.

--- a/.wercker.yml
+++ b/.wercker.yml
@@ -12,6 +12,7 @@ build:
                 conda config --set show_channel_urls True
                 conda config --add channels conda-forge
                 source activate root
+                echo "conda-build 1.*" >> /opt/conda/conda-meta/pinned
                 conda update -y --all
                 python setup.py bdist_conda
 


### PR DESCRIPTION
Pin to conda-build 1.x to get a working bdist_conda.

xref: https://github.com/conda/conda-build/issues/1305
