### PR TITLE
Drop Sphinx 1.3 pin

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,6 @@ install:
    - export DRMAA_LIBRARY_PATH=/usr/lib/libdrmaa.so.1.0
    - conda install drmaa
    # Install sphinx 1.3 and friends to build documentation.
-   - echo "sphinx 1.3.*" >> $HOME/miniconda/envs/testenv/conda-meta/pinned
    - conda install sphinx
    - conda install cloud_sptheme
    # Install coverage and coveralls to generate and submit test coverage results for coveralls.io.

--- a/.wercker.yml
+++ b/.wercker.yml
@@ -30,7 +30,6 @@ build:
         - script:
             name: Install dependencies for building docs.
             code: |-
-                echo "sphinx 1.3.*" >> /opt/conda/envs/testenv/conda-meta/pinned
                 conda install -y sphinx
                 conda install -y cloud_sptheme
 


### PR DESCRIPTION
Seems Sphinx 1.3 is getting us into trouble with `docutils`. So drop this pin so that we can use Sphinx 1.5, which avoids this issue.