### PR TITLE
Unpin conda-build from 1.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,6 @@ install:
    - conda update --all
    # Fix root environment to have the correct Python version.
    - touch $HOME/miniconda/conda-meta/pinned
-   - echo "conda-build 1.*" >> $HOME/miniconda/conda-meta/pinned
    - echo "python ${PYTHON_VERSION}.*" >> $HOME/miniconda/conda-meta/pinned
    - conda install python=$PYTHON_VERSION
    # Install basic conda dependencies.

--- a/.wercker.yml
+++ b/.wercker.yml
@@ -12,7 +12,6 @@ build:
                 conda config --set show_channel_urls True
                 conda config --add channels conda-forge
                 source activate root
-                echo "conda-build 1.*" >> /opt/conda/conda-meta/pinned
                 conda update -y --all
                 python setup.py bdist_conda
 


### PR DESCRIPTION
Was pinned to `conda-build` 1.x due to a `bdist_conda` bug in `conda-build` 2.0.0, which has long since been fixed. So try simply unpinning `conda-build` to see if things just work.

xref: https://github.com/jakirkham/splauncher/pull/35