### PR TITLE
Support coverage 4.x

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,7 +1,6 @@
 [run]
 branch = True
-erase = True
-package = splauncher
+source = splauncher
 [report]
 exclude_lines =
     # Ignore coverage of code that requires the module to be executed.

--- a/.travis.yml
+++ b/.travis.yml
@@ -57,6 +57,8 @@ install:
    - conda clean -tipsy
    - rm -rfv $HOME/.cache/pip
 script:
+   # Clear old coverage.
+   - coverage erase
    # Run tests. Skip 3D tests as they take too long (~1hr).
    - python setup.py nosetests --with-timer
    # Build documentation.

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,7 +49,6 @@ install:
    # Install coverage and coveralls to generate and submit test coverage results for coveralls.io.
    # Also, install docstring-coverage to get information about documentation coverage.
    - conda install nose-timer
-   - echo "coverage 3.*" >> $HOME/miniconda/envs/testenv/conda-meta/pinned
    - conda install coverage
    - conda install docstring-coverage || true
    - conda install python-coveralls

--- a/.wercker.yml
+++ b/.wercker.yml
@@ -36,7 +36,6 @@ build:
             name: Install dependencies for profiling and monitoring coverage.
             code: |-
                 conda install -y nose-timer
-                echo "coverage 3.*" >> /opt/conda/envs/testenv/conda-meta/pinned
                 conda install -y coverage
                 conda install -y docstring-coverage
                 conda install -y python-coveralls

--- a/.wercker.yml
+++ b/.wercker.yml
@@ -48,6 +48,7 @@ build:
         - script:
             name: Test code.
             code: |-
+                coverage erase
                 python setup.py nosetests --with-timer
 
         - script:


### PR DESCRIPTION
Adjust `.coveragerc` to support `coverage` 4.x. Then unpin `coverage` so as to use 4.x.