### PR TITLE
Pin nose-timer to 0.6.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,6 +48,7 @@ install:
    - conda install cloud_sptheme
    # Install coverage and coveralls to generate and submit test coverage results for coveralls.io.
    # Also, install docstring-coverage to get information about documentation coverage.
+   - echo "nose-timer 0.6.0" >> $HOME/miniconda/envs/testenv/conda-meta/pinned
    - conda install nose-timer
    - conda install coverage
    - conda install docstring-coverage || true

--- a/.wercker.yml
+++ b/.wercker.yml
@@ -35,6 +35,7 @@ build:
         - script:
             name: Install dependencies for profiling and monitoring coverage.
             code: |-
+                echo "nose-timer 0.6.0" >> "$(conda info --root)/envs/testenv/conda-meta/pinned"
                 conda install -y nose-timer
                 conda install -y coverage
                 conda install -y docstring-coverage


### PR DESCRIPTION
Appears that the `--with-timer` option is not working correctly with the 0.7.0 package from `conda-forge`. Not entirely sure why, but am going to try pinning to the last known working version.