### PR TITLE
Only use the Read the Docs badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,4 +1,4 @@
-|Travis Build Status| |Wercker Build Status| |Coverage Status| |Code Health| |License| |Documentation| |Read the Docs| |Anaconda Release|
+|Travis Build Status| |Wercker Build Status| |Coverage Status| |Code Health| |License| |Documentation| |Anaconda Release|
 
 --------------
 
@@ -54,9 +54,7 @@ way (as seen below).
    :target: https://landscape.io/github/jakirkham/splauncher/master
 .. |License| image:: https://img.shields.io/badge/license-BSD%203--Clause-blue.svg
    :target: http://opensource.org/licenses/BSD-3-Clause
-.. |Documentation| image:: https://img.shields.io/badge/docs-current-9F21E9.svg
-   :target: http://jakirkham.github.io/splauncher/
-.. |Read the Docs| image:: https://readthedocs.org/projects/splauncher/badge/?version=latest
+.. |Documentation| image:: https://readthedocs.org/projects/splauncher/badge/?version=latest
    :target: https://splauncher.readthedocs.io/en/latest/?badge=latest
 .. |Anaconda Release| image:: https://anaconda.org/conda-forge/splauncher/badges/version.svg
    :target: https://anaconda.org/conda-forge/splauncher


### PR DESCRIPTION
As the GitHub Page has been scrapped and replaced with a redirect to Read the Docs, simply drop that badge and only include the Read the Docs badge for documentation.