### PR TITLE
Skip handling test requirements for `bdist_conda`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,9 +24,7 @@ if len(sys.argv) == 1:
 elif ("--help" in sys.argv) or ("-h" in sys.argv):
     pass
 elif sys.argv[1] == "bdist_conda":
-    tests_require = [
-        "nose"
-    ]
+    pass
 elif sys.argv[1] == "build_sphinx":
     import sphinx.apidoc
 


### PR DESCRIPTION
There is no need to handle the case of `bdist_conda` specially with respect to test requirements. We already add `nose` as a test requirement regardless of whether `bdist_conda` is specified. So this is merely redundant code that can be dropped.