### PR TITLE
Use unittests

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -99,6 +99,6 @@ setup(
     build_requires=build_requires,
     install_requires=install_requires,
     tests_require=tests_require,
-    test_suite="nose.collector",
+    test_suite="tests",
     zip_safe=True
 )

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ import versioneer
 
 build_requires = []
 install_requires = []
-tests_require = ["nose"]
+tests_require = []
 sphinx_build_pdf = False
 if len(sys.argv) == 1:
     pass

--- a/tests/test_splauncher/test_core.py
+++ b/tests/test_splauncher/test_core.py
@@ -90,3 +90,8 @@ class TestCore(unittest.TestCase):
             s = f.read().strip()
             print("File \"%s\" contains \"%s\"." % (f.name, s))
             assert s == ""
+
+
+if __name__ == '__main__':
+    import sys
+    sys.exit(unittest.main())

--- a/tests/test_splauncher/test_core.py
+++ b/tests/test_splauncher/test_core.py
@@ -9,12 +9,13 @@ import os
 import shutil
 import tempfile
 import time
+import unittest
 
 from splauncher.core import main
 
 
-class TestCore(object):
-    def setup(self):
+class TestCore(unittest.TestCase):
+    def setUp(self):
         self.cwd = os.getcwd()
         self.tempdir = ""
         self.tempdir = tempfile.mkdtemp()
@@ -22,7 +23,7 @@ class TestCore(object):
 
         print("tempdir = \"%s\"" % self.tempdir)
 
-    def teardown(self):
+    def tearDown(self):
         os.chdir(self.cwd)
         shutil.rmtree(self.tempdir)
         self.tempdir = ""


### PR DESCRIPTION
Switch to using the builtin `unittests` directly for the test suite and make `nose` optional. However continue to use `nose` to run the tests in CI.