### PR TITLE
Specify type of BSD in setup metadata

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -89,7 +89,7 @@ setup(
     version=versioneer.get_version(),
     description="A simple subprocess launcher with optional DRMAA support.",
     url="https://github.com/jakirkham/splauncher",
-    license="BSD",
+    license="BSD 3-Clause",
     author="John Kirkham",
     author_email="kirkhamj@janelia.hhmi.org",
     scripts=glob("bin/*"),


### PR DESCRIPTION
Should specify BSD 3-Clause instead of just BSD. Hence that change is made to the `setup` `license` metadata.