### PR TITLE
Fix versioneer 0.15 install

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,3 @@
 include LICENSE.txt
+include versioneer.py
+include splauncher/_version.py

--- a/splauncher/__init__.py
+++ b/splauncher/__init__.py
@@ -3,5 +3,5 @@ __date__ = "$May 18, 2015 16:46:39 EDT$"
 
 
 from ._version import get_versions
-__version__ = get_versions()["version"]
+__version__ = get_versions()['version']
 del get_versions


### PR DESCRIPTION
Some files were missing from the `MANIFEST.in`, which have now been added. Also there was a formatting change to the version import in `splauncher`'s `__init__` module, which has been corrected.