### PR TITLE
Drop native specification

### DIFF
--- a/splauncher/core.py
+++ b/splauncher/core.py
@@ -53,7 +53,6 @@ def main(*argv):
     job_template.outputPath = "localhost:" + job_name + ".out"
     job_template.errorPath = "localhost:" + job_name + ".err"
     job_template.workingDirectory = os.getcwd()
-    job_template.nativeSpecification = "-pe batch " + str(1)
 
     process_id = s.runJob(job_template)
     s.deleteJobTemplate(job_template)


### PR DESCRIPTION
Fixes https://github.com/jakirkham/splauncher/issues/59

As this ends up being specific to the cluster that it is being run on and may not be accurate for all DRMAA instances, simply drop the native specification as it seems we are able to run without this.